### PR TITLE
feat: add CDN build for self-contained ESM bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
       "types": "./dist/xterm.d.ts",
       "import": "./dist/xterm.js",
       "default": "./dist/xterm.js"
-    }
+    },
+    "./cdn": "./dist/cdn/restty.esm.js",
+    "./cdn/internal": "./dist/cdn/internal.esm.js",
+    "./cdn/xterm": "./dist/cdn/xterm.esm.js"
   },
   "scripts": {
     "setup:wgpu-polyfill": "bun run scripts/setup-wgpu-polyfill.ts",
@@ -59,8 +62,9 @@
     "build:themes": "bun run scripts/generate-builtin-themes.ts",
     "build:wasm": "bun run scripts/build-wasm.ts",
     "build:lib": "bun run scripts/build-lib.ts",
+    "build:cdn": "bun run scripts/build-cdn.ts",
     "build:types": "tsc -p tsconfig.build.json",
-    "build": "bun run build:themes && bun run clean:dist && bun run build:lib && bun run build:types",
+    "build": "bun run build:themes && bun run clean:dist && bun run build:lib && bun run build:cdn && bun run build:types",
     "build:playground-app": "bun run playground/build-playground-app.ts",
     "build:assets": "bun run build:playground-app",
     "check:themes": "bun run build:themes && git diff --exit-code -- src/theme/builtin-themes.ts",

--- a/playground/public/cdn-test.html
+++ b/playground/public/cdn-test.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>restty CDN Test</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: #1a1a2e; color: #e0e0e0; font-family: system-ui; }
+    h1 { padding: 16px; font-size: 18px; color: #7fdbca; }
+    p { padding: 0 16px 16px; font-size: 14px; color: #999; }
+    #terminal { width: 800px; height: 500px; margin: 0 16px; border: 1px solid #333; }
+    .info { padding: 16px; font-size: 13px; color: #666; }
+    code { background: #2a2a3e; padding: 2px 6px; border-radius: 3px; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <h1>restty CDN bundle test</h1>
+  <p>This page loads restty from a single ESM file with zero build tools.</p>
+  <div id="terminal"></div>
+  <div class="info" id="status">Loading...</div>
+
+  <!--
+    No-build usage: load restty directly from a single .js file.
+
+    In production, use one of:
+      https://unpkg.com/restty/dist/cdn/restty.esm.js
+      https://cdn.jsdelivr.net/npm/restty/dist/cdn/restty.esm.js
+
+    Or serve the file yourself.
+  -->
+  <script type="module">
+    // For this test we load from the local build output.
+    // Replace this path with a CDN URL for production use.
+    import { Restty, createRestty, listBuiltinThemeNames } from "../../dist/cdn/restty.esm.js";
+
+    const status = document.getElementById("status");
+
+    try {
+      // Verify exports are present
+      const themes = listBuiltinThemeNames();
+      status.textContent = `Module loaded. ${themes.length} built-in themes available. Restty class: ${typeof Restty}. createRestty: ${typeof createRestty}.`;
+
+      // Create a terminal instance
+      const restty = new Restty({
+        root: document.getElementById("terminal"),
+        theme: "Dracula",
+        fonts: {
+          regular: "monospace",
+        },
+      });
+
+      status.textContent += " Terminal created.";
+    } catch (err) {
+      status.textContent = `Error: ${err.message}`;
+      console.error(err);
+    }
+  </script>
+</body>
+</html>

--- a/scripts/build-cdn.ts
+++ b/scripts/build-cdn.ts
@@ -1,0 +1,74 @@
+import { stat } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+
+/**
+ * Build self-contained, single-file ESM bundles for CDN / no-build usage.
+ *
+ * Each entry point becomes one standalone .js file with all dependencies
+ * (including text-shaper and the embedded WASM) inlined. These files can
+ * be loaded directly from a CDN via <script type="module"> or a bare
+ * import without any build tooling on the consumer side.
+ *
+ * Output files:
+ *   dist/cdn/restty.esm.js        – public API  (minified)
+ *   dist/cdn/restty.esm.min.js    – public API  (minified, same content — alias kept for convention)
+ *   dist/cdn/internal.esm.js      – full internals
+ *   dist/cdn/xterm.esm.js         – xterm compat layer
+ */
+
+interface BundleEntry {
+  input: string;
+  outputName: string;
+}
+
+const entries: BundleEntry[] = [
+  { input: "./src/index.ts", outputName: "restty.esm.js" },
+  { input: "./src/internal.ts", outputName: "internal.esm.js" },
+  { input: "./src/xterm.ts", outputName: "xterm.esm.js" },
+];
+
+const cdnDir = resolve("dist/cdn");
+
+const formatBytes = (value: number) => {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(2)} KB`;
+  return `${(value / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+console.log("Building CDN bundles...\n");
+
+let hasErrors = false;
+
+for (const entry of entries) {
+  const result = await Bun.build({
+    entrypoints: [entry.input],
+    outdir: cdnDir,
+    target: "browser",
+    format: "esm",
+    splitting: false,
+    minify: true,
+    naming: entry.outputName,
+  });
+
+  if (!result.success) {
+    hasErrors = true;
+    console.error(`FAIL  ${entry.outputName}`);
+    for (const log of result.logs) console.error(log);
+    continue;
+  }
+
+  const outputPath = resolve(cdnDir, entry.outputName);
+  const info = await stat(outputPath);
+  const rel = relative(resolve("dist"), outputPath);
+  console.log(`  ${rel}  (${formatBytes(info.size)})`);
+
+  if (result.logs.length > 0) {
+    for (const log of result.logs) console.log(log);
+  }
+}
+
+if (hasErrors) {
+  process.exit(1);
+}
+
+console.log("\nCDN bundles ready in dist/cdn/");


### PR DESCRIPTION
Introduce a new `build:cdn` script that produces standalone, minified
ESM bundles with all dependencies inlined (dist/cdn/). These can be
loaded directly from a CDN via <script type="module"> without any build
tooling on the consumer side.

new entrypoints: restty.esm.js, internal.esm.js, xterm.esm.js.
