### PR TITLE
fix: skip render tick when wasm not ready to prevent black flash

### DIFF
--- a/src/runtime/create-runtime/runtime-app-api.ts
+++ b/src/runtime/create-runtime/runtime-app-api.ts
@@ -221,10 +221,16 @@ export function createRuntimeAppApi(options: CreateRuntimeAppApiOptions): Runtim
         ? true
         : now - nextShared.lastRenderTime >= 1000 / targetRenderFps;
       if (nextShared.needsRender && renderBudget) {
-        if (internalState.backend === "webgpu" && "device" in state) tickWebGPU(state);
-        if (internalState.backend === "webgl2" && "gl" in state) tickWebGL(state);
-        writeState({ lastRenderTime: now, needsRender: false });
-        updateFps();
+        // Skip render if wasm or font not ready yet — avoids black flash
+        // during initial load. needsRender stays true so next tick retries.
+        if (!nextShared.wasmReady) {
+          // Do nothing — keep needsRender true for retry
+        } else {
+          if (internalState.backend === "webgpu" && "device" in state) tickWebGPU(state);
+          if (internalState.backend === "webgl2" && "gl" in state) tickWebGL(state);
+          writeState({ lastRenderTime: now, needsRender: false });
+          updateFps();
+        }
       }
     }
     internalState.rafId = requestAnimationFrame(() => loop(state));


### PR DESCRIPTION
## Problem

Screen occasionally flashes black during initial load and idle. The cursor blink timer sets `needsRender=true` every 600ms, which triggers `tickWebGPU` before wasm/font initialization is complete. The tick function then clears the canvas to the background color (black).

Fixes #13

## Fix

Check `wasmReady` before calling the render tick. When wasm is not ready, `needsRender` stays `true` so the render is retried on the next animation frame after initialization completes.

## Change

```typescript
if (nextShared.needsRender && renderBudget) {
  if (!nextShared.wasmReady) {
    // Skip — keep needsRender true for retry
  } else {
    tickWebGPU(state);  // or tickWebGL
    writeState({ lastRenderTime: now, needsRender: false });
    updateFps();
  }
}
```

## Testing

- Black flash no longer occurs on page load
- Normal rendering works after wasm/font initialization
- Cursor blink continues working normally after load