### PR TITLE
feat: add resize overlay toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ On touch devices, restty defaults to pan-first scrolling with long-press selecti
 const restty = new Restty({
   root: document.getElementById("terminal") as HTMLElement,
   appOptions: {
+    showResizeOverlay: false,
     // "long-press" (default) | "drag" | "off"
     touchSelectionMode: "long-press",
     // Optional tuning knobs:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,6 +38,7 @@ const restty = new Restty({
     renderer: "auto", // "auto" | "webgpu" | "webgl2"
     fontSize: 16,
     ligatures: true,
+    showResizeOverlay: true,
     // Optional text-shaper hinting controls:
     // hinting off by default for parity/thickness reasons.
     fontHinting: false,

--- a/src/runtime/create-runtime.ts
+++ b/src/runtime/create-runtime.ts
@@ -316,8 +316,9 @@ export function createResttyApp(options: ResttyAppOptions): ResttyApp {
   let wasmHandle = 0;
   let wasmReady = false;
   let activeState: WebGPUState | WebGLState | null = null;
-  const RESIZE_OVERLAY_HOLD_MS = 500;
-  const RESIZE_OVERLAY_FADE_MS = 400;
+  const showResizeOverlay = options.showResizeOverlay ?? true;
+  const RESIZE_OVERLAY_HOLD_MS = showResizeOverlay ? 500 : 0;
+  const RESIZE_OVERLAY_FADE_MS = showResizeOverlay ? 400 : 0;
   const RESIZE_ACTIVE_MS = 180;
   const resizeState = {
     active: false,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -280,6 +280,8 @@ export type ResttyAppOptions = {
   nerdIconScale?: number;
   /** Automatically resize the terminal on container/window changes (default true). */
   autoResize?: boolean;
+  /** Show the centered `cols x rows` badge while the terminal is resizing (default true). */
+  showResizeOverlay?: boolean;
   /** Attach resize/focus listeners to the window object. */
   attachWindowEvents?: boolean;
   /** Attach pointer/keyboard listeners to the canvas. */

--- a/tests/resize-overlay-option.test.ts
+++ b/tests/resize-overlay-option.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test";
+import { populateWebGLOverlays } from "../src/runtime/create-runtime/render-tick-webgl-overlays";
+
+function createOverlayContext(options: {
+  cols: number;
+  rows: number;
+  holdMs: number;
+  fadeMs: number;
+}) {
+  const overlayQueue: Array<Record<string, unknown>> = [];
+  const overlayGlyphSet = new Set<number>();
+  const overlayData: number[] = [];
+
+  const ctx = {
+    deps: {
+      fontState: { fonts: [{ font: {} }] },
+      pickFontIndexForText: () => 0,
+      fitTextTailToWidth: () => ({ text: "", widthPx: 0, offset: 0 }),
+      shapeClusterWithFont: (_entry: unknown, text: string) => ({
+        advance: text.length * 10,
+        glyphs: [{ glyphId: 101 }],
+      }),
+      noteColorGlyphText: () => undefined,
+      imeState: { preedit: "", selectionStart: 0, selectionEnd: 0 },
+      PREEDIT_BG: [0, 0, 0, 1],
+      PREEDIT_UL: [0, 0, 0, 1],
+      PREEDIT_ACTIVE_BG: [0, 0, 0, 1],
+      PREEDIT_CARET: [0, 0, 0, 1],
+      PREEDIT_FG: [1, 1, 1, 1],
+      resizeState: {
+        lastAt: performance.now(),
+        cols: options.cols,
+        rows: options.rows,
+      },
+      RESIZE_OVERLAY_HOLD_MS: options.holdMs,
+      RESIZE_OVERLAY_FADE_MS: options.fadeMs,
+      canvas: { width: 800, height: 480 },
+      pushRect: () => undefined,
+      pushRectBox: (target: number[], ...values: number[]) => {
+        target.push(...values);
+      },
+      decodePackedRGBA: () => [1, 1, 1, 1],
+      cursorFallback: [1, 1, 1, 1],
+      clamp: (value: number, min: number, max: number) => Math.min(max, Math.max(min, value)),
+      wasmExports: null,
+      wasmHandle: 0,
+      scrollbarState: { lastTotal: 0, lastOffset: 0, lastLen: 0 },
+      syncScrollbar: () => undefined,
+    },
+    rows: options.rows,
+    cols: options.cols,
+    cursor: null,
+    cursorPos: null,
+    cursorStyle: null,
+    cursorCell: null,
+    cursorImeAnchor: null,
+    cellW: 10,
+    cellH: 20,
+    primaryScale: 1,
+    lineHeight: 20,
+    baselineOffset: 15,
+    yPad: 0,
+    underlineOffsetPx: 0,
+    underlineThicknessPx: 1,
+    bgData: [],
+    underlineData: [],
+    cursorData: [],
+    fgRectData: [],
+    overlayData,
+    scaleByFont: [1],
+    getGlyphQueue: () => [],
+    getOverlayGlyphQueue: () => overlayQueue,
+    getGlyphSet: () => overlayGlyphSet,
+  };
+
+  return {
+    ctx,
+    overlayData,
+    overlayGlyphSet,
+    overlayQueue,
+  };
+}
+
+test("populateWebGLOverlays renders the resize badge by default", () => {
+  const { ctx, overlayData, overlayGlyphSet, overlayQueue } = createOverlayContext({
+    cols: 120,
+    rows: 30,
+    holdMs: 500,
+    fadeMs: 400,
+  });
+
+  populateWebGLOverlays(ctx as never);
+
+  expect(overlayData.length).toBeGreaterThan(0);
+  expect(overlayGlyphSet.size).toBeGreaterThan(0);
+  expect(overlayQueue).toHaveLength(1);
+});
+
+test("populateWebGLOverlays skips the resize badge when disabled", () => {
+  const { ctx, overlayData, overlayGlyphSet, overlayQueue } = createOverlayContext({
+    cols: 120,
+    rows: 30,
+    holdMs: 0,
+    fadeMs: 0,
+  });
+
+  populateWebGLOverlays(ctx as never);
+
+  expect(overlayData).toHaveLength(0);
+  expect(overlayGlyphSet.size).toBe(0);
+  expect(overlayQueue).toHaveLength(0);
+});


### PR DESCRIPTION
Hey @wiedymi, very small option that I need for my app if you don't mind.

The code is minimal, the test file might not be needed to. Please feel free to edit the PR as you wish.
This was done by GPT 5.4 in Codex CLI and checked by me.

## Summary
- add a `showResizeOverlay` app option so consumers can disable the centered `cols x rows` badge during resize
- wire the option into the shared resize overlay timing used by both renderers
- document the option and add a regression test covering enabled and disabled overlay rendering

## Validation
- bun test tests/resize-overlay-option.test.ts
- bun run format:check
- bun run lint
- bun run build:types