### PR TITLE
feat: add headless terminal and serialize addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,24 +33,39 @@
     "LICENSE"
   ],
   "type": "module",
-  "main": "./dist/restty.js",
+  "main": "./dist/restty.cjs",
   "module": "./dist/restty.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/restty.js",
+      "require": "./dist/restty.cjs",
       "default": "./dist/restty.js"
     },
     "./internal": {
       "types": "./dist/internal.d.ts",
       "import": "./dist/internal.js",
+      "require": "./dist/internal.cjs",
       "default": "./dist/internal.js"
     },
     "./xterm": {
       "types": "./dist/xterm.d.ts",
       "import": "./dist/xterm.js",
+      "require": "./dist/xterm.cjs",
       "default": "./dist/xterm.js"
+    },
+    "./headless": {
+      "types": "./dist/headless.d.ts",
+      "import": "./dist/headless.js",
+      "require": "./dist/headless.cjs",
+      "default": "./dist/headless.js"
+    },
+    "./serialize": {
+      "types": "./dist/serialize.d.ts",
+      "import": "./dist/serialize.js",
+      "require": "./dist/serialize.cjs",
+      "default": "./dist/serialize.js"
     },
     "./esm": {
       "types": "./dist/index.d.ts",
@@ -66,6 +81,16 @@
       "types": "./dist/xterm.d.ts",
       "import": "./dist/xterm.esm.js",
       "default": "./dist/xterm.esm.js"
+    },
+    "./esm/headless": {
+      "types": "./dist/headless.d.ts",
+      "import": "./dist/headless.esm.js",
+      "default": "./dist/headless.esm.js"
+    },
+    "./esm/serialize": {
+      "types": "./dist/serialize.d.ts",
+      "import": "./dist/serialize.esm.js",
+      "default": "./dist/serialize.esm.js"
     }
   },
   "scripts": {
@@ -74,9 +99,10 @@
     "build:themes": "bun run scripts/generate-builtin-themes.ts",
     "build:wasm": "bun run scripts/build-wasm.ts",
     "build:lib": "bun run scripts/build-lib.ts",
+    "build:cjs": "bun run scripts/build-cjs.ts",
     "build:esm": "bun run scripts/build-esm.ts",
     "build:types": "tsc -p tsconfig.build.json",
-    "build": "bun run build:themes && bun run clean:dist && bun run build:lib && bun run build:esm && bun run build:types",
+    "build": "bun run build:themes && bun run clean:dist && bun run build:lib && bun run build:cjs && bun run build:esm && bun run build:types",
     "build:playground-app": "bun run playground/build-playground-app.ts",
     "build:assets": "bun run build:playground-app",
     "check:themes": "bun run build:themes && git diff --exit-code -- src/theme/builtin-themes.ts",

--- a/scripts/build-cjs.ts
+++ b/scripts/build-cjs.ts
@@ -7,11 +7,11 @@ type BundleEntry = {
 };
 
 const entries: BundleEntry[] = [
-  { input: "./src/index.ts", outputName: "restty.esm.js" },
-  { input: "./src/internal.ts", outputName: "internal.esm.js" },
-  { input: "./src/xterm.ts", outputName: "xterm.esm.js" },
-  { input: "./src/headless.ts", outputName: "headless.esm.js" },
-  { input: "./src/serialize.ts", outputName: "serialize.esm.js" },
+  { input: "./src/index.ts", outputName: "restty.cjs" },
+  { input: "./src/internal.ts", outputName: "internal.cjs" },
+  { input: "./src/xterm.ts", outputName: "xterm.cjs" },
+  { input: "./src/headless.ts", outputName: "headless.cjs" },
+  { input: "./src/serialize.ts", outputName: "serialize.cjs" },
 ];
 
 const distDir = resolve("dist");
@@ -22,7 +22,7 @@ const formatBytes = (value: number) => {
   return `${(value / (1024 * 1024)).toFixed(2)} MB`;
 };
 
-console.log("Building standalone ESM bundles...\n");
+console.log("Building standalone CJS bundles...\n");
 
 let hasErrors = false;
 
@@ -30,10 +30,10 @@ for (const entry of entries) {
   const result = await Bun.build({
     entrypoints: [entry.input],
     outdir: distDir,
-    target: "browser",
-    format: "esm",
+    target: "node",
+    format: "cjs",
     splitting: false,
-    minify: true,
+    minify: false,
     naming: entry.outputName,
   });
 
@@ -57,4 +57,4 @@ if (hasErrors) {
   process.exit(1);
 }
 
-console.log("\nStandalone ESM bundles ready in dist/");
+console.log("\nStandalone CJS bundles ready in dist/");

--- a/scripts/build-lib.ts
+++ b/scripts/build-lib.ts
@@ -5,6 +5,8 @@ const entrypoints = [
   "./src/index.ts",
   "./src/internal.ts",
   "./src/xterm.ts",
+  "./src/headless.ts",
+  "./src/serialize.ts",
 ];
 
 const result = await Bun.build({

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,0 +1,294 @@
+import type { CursorInfo, RenderState, ResttyWasm } from "./wasm";
+import { loadResttyWasm } from "./wasm";
+import { addListener, emitWithGuard } from "./xterm/listeners";
+import { normalizeDimension } from "./xterm/dimensions";
+
+export type IDisposable = {
+  dispose: () => void;
+};
+
+export type TerminalResizeEvent = {
+  cols: number;
+  rows: number;
+};
+
+export type TerminalAddon = {
+  activate: (terminal: Terminal) => void;
+  dispose: () => void;
+};
+
+export type HeadlessTerminalOptions = {
+  cols?: number;
+  rows?: number;
+  maxScrollbackBytes?: number;
+};
+
+export type HeadlessTerminalSnapshot = {
+  cols: number;
+  rows: number;
+  cursor: CursorInfo | null;
+  historyByteLength: number;
+  renderState: RenderState | null;
+};
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const DEFAULT_MAX_SCROLLBACK_BYTES = 10_000_000;
+const HARD_RESET_SEQUENCE = "\u001bc";
+const JOURNAL_COMPACT_CHUNK_COUNT = 128;
+
+function decodeInputPayload(
+  payload: string | Uint8Array | ArrayBuffer,
+  decoder: TextDecoder,
+): string {
+  if (typeof payload === "string") {
+    return payload;
+  }
+  if (payload instanceof Uint8Array) {
+    return decoder.decode(payload);
+  }
+  return decoder.decode(new Uint8Array(payload));
+}
+
+export class Terminal {
+  private readonly addons = new Set<TerminalAddon>();
+  private readonly dataListeners = new Set<(data: string) => void>();
+  private readonly resizeListeners = new Set<(size: TerminalResizeEvent) => void>();
+  private readonly textDecoder = new TextDecoder();
+  private readonly textEncoder = new TextEncoder();
+  private readonly maxScrollbackBytes: number;
+  private readonly startupPromise: Promise<void>;
+
+  private operationQueue: Promise<void> = Promise.resolve();
+  private wasm: ResttyWasm | null = null;
+  private wasmHandle = 0;
+  private disposed = false;
+  private lastRenderState: RenderState | null = null;
+  private journalChunks: string[] = [];
+  private journalByteLength = 0;
+  private journalCache = "";
+  private journalDirty = false;
+
+  cols: number;
+  rows: number;
+
+  constructor(options: HeadlessTerminalOptions = {}) {
+    this.cols = normalizeDimension(options.cols, DEFAULT_COLS);
+    this.rows = normalizeDimension(options.rows, DEFAULT_ROWS);
+    this.maxScrollbackBytes = Number.isFinite(options.maxScrollbackBytes)
+      ? Math.max(0, Number(options.maxScrollbackBytes))
+      : DEFAULT_MAX_SCROLLBACK_BYTES;
+    this.startupPromise = this.initialize();
+  }
+
+  public whenReady(): Promise<void> {
+    return this.startupPromise;
+  }
+
+  public whenIdle(): Promise<void> {
+    return this.operationQueue;
+  }
+
+  public getSnapshot(): HeadlessTerminalSnapshot {
+    return {
+      cols: this.cols,
+      rows: this.rows,
+      cursor: this.lastRenderState?.cursor ?? null,
+      historyByteLength: this.journalByteLength,
+      renderState: this.lastRenderState,
+    };
+  }
+
+  public serializeReplay(): string {
+    if (!this.journalDirty) {
+      return this.journalCache;
+    }
+    this.journalCache = this.journalChunks.join("");
+    this.journalDirty = false;
+    return this.journalCache;
+  }
+
+  public write(data: string | Uint8Array | ArrayBuffer, callback?: () => void): void {
+    const text = decodeInputPayload(data, this.textDecoder);
+    if (!text) {
+      callback?.();
+      return;
+    }
+
+    this.appendToJournal(text);
+    void this.enqueue(async () => {
+      this.writeToWasm(text);
+      callback?.();
+    });
+  }
+
+  public writeln(data = "", callback?: () => void): void {
+    this.write(`${data}\r\n`, callback);
+  }
+
+  public resize(cols: number, rows: number): void {
+    const nextCols = normalizeDimension(cols, this.cols);
+    const nextRows = normalizeDimension(rows, this.rows);
+    void this.enqueue(async () => {
+      this.cols = nextCols;
+      this.rows = nextRows;
+      if (this.wasm && this.wasmHandle) {
+        this.wasm.resize(this.wasmHandle, nextCols, nextRows);
+        this.refreshRenderState();
+      }
+      emitWithGuard(this.resizeListeners, { cols: nextCols, rows: nextRows }, "onResize");
+    });
+  }
+
+  public clear(): void {
+    this.write("\u001b[H\u001b[2J");
+  }
+
+  public reset(): void {
+    this.resetJournal(HARD_RESET_SEQUENCE);
+    void this.enqueue(async () => {
+      this.writeToWasm(HARD_RESET_SEQUENCE);
+    });
+  }
+
+  public onData(listener: (data: string) => void): IDisposable {
+    return addListener(this.dataListeners, listener);
+  }
+
+  public onResize(listener: (size: TerminalResizeEvent) => void): IDisposable {
+    return addListener(this.resizeListeners, listener);
+  }
+
+  public loadAddon(addon: TerminalAddon): void {
+    this.ensureUsable();
+    if (!addon || typeof addon.activate !== "function" || typeof addon.dispose !== "function") {
+      throw new Error("headless addon must define activate() and dispose()");
+    }
+    if (this.addons.has(addon)) {
+      return;
+    }
+    addon.activate(this);
+    this.addons.add(addon);
+  }
+
+  public dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+
+    const addons = Array.from(this.addons);
+    this.addons.clear();
+    for (let i = 0; i < addons.length; i += 1) {
+      try {
+        addons[i].dispose();
+      } catch {
+        // Ignore addon cleanup errors to keep disposal resilient.
+      }
+    }
+
+    this.dataListeners.clear();
+    this.resizeListeners.clear();
+
+    const destroy = async () => {
+      await this.startupPromise.catch(() => undefined);
+      if (this.wasm && this.wasmHandle) {
+        this.wasm.destroy(this.wasmHandle);
+        this.wasmHandle = 0;
+      }
+      this.wasm = null;
+      this.lastRenderState = null;
+      this.journalChunks = [];
+      this.journalCache = "";
+      this.journalDirty = false;
+      this.journalByteLength = 0;
+    };
+
+    this.operationQueue = this.operationQueue.then(destroy, destroy);
+  }
+
+  private ensureUsable(): void {
+    if (this.disposed) {
+      throw new Error("headless Terminal is disposed");
+    }
+  }
+
+  private async initialize(): Promise<void> {
+    const wasm = await loadResttyWasm();
+    if (this.disposed) {
+      return;
+    }
+    this.wasm = wasm;
+    this.wasmHandle = wasm.create(this.cols, this.rows, this.maxScrollbackBytes);
+    this.refreshRenderState();
+  }
+
+  private enqueue(run: () => void | Promise<void>): Promise<void> {
+    this.ensureUsable();
+    const wrapped = async () => {
+      await this.startupPromise;
+      if (this.disposed) {
+        return;
+      }
+      await run();
+    };
+    this.operationQueue = this.operationQueue.then(wrapped, wrapped);
+    return this.operationQueue;
+  }
+
+  private writeToWasm(text: string): void {
+    if (!this.wasm || !this.wasmHandle) {
+      return;
+    }
+    this.wasm.write(this.wasmHandle, text);
+    this.refreshRenderState();
+    this.flushTerminalReplies();
+  }
+
+  private refreshRenderState(): void {
+    if (!this.wasm || !this.wasmHandle) {
+      return;
+    }
+    this.wasm.renderUpdate(this.wasmHandle);
+    this.lastRenderState = this.wasm.getRenderState(this.wasmHandle);
+  }
+
+  private flushTerminalReplies(): void {
+    if (!this.wasm || !this.wasmHandle) {
+      return;
+    }
+    let iterations = 0;
+    while (iterations < 32) {
+      const reply = this.wasm.drainOutput(this.wasmHandle);
+      if (!reply) {
+        break;
+      }
+      emitWithGuard(this.dataListeners, reply, "onData");
+      iterations += 1;
+    }
+  }
+
+  private appendToJournal(text: string): void {
+    const hardResetIndex = text.lastIndexOf(HARD_RESET_SEQUENCE);
+    if (hardResetIndex >= 0) {
+      this.resetJournal(text.slice(hardResetIndex));
+      return;
+    }
+
+    this.journalChunks.push(text);
+    this.journalByteLength += this.textEncoder.encode(text).length;
+    this.journalDirty = true;
+
+    if (this.journalChunks.length >= JOURNAL_COMPACT_CHUNK_COUNT) {
+      this.journalChunks = [this.serializeReplay()];
+      this.journalDirty = false;
+    }
+  }
+
+  private resetJournal(text: string): void {
+    this.journalChunks = [text];
+    this.journalCache = text;
+    this.journalDirty = false;
+    this.journalByteLength = this.textEncoder.encode(text).length;
+  }
+}

--- a/src/runtime/create-runtime.ts
+++ b/src/runtime/create-runtime.ts
@@ -1226,6 +1226,7 @@ export function createResttyApp(options: ResttyAppOptions): ResttyApp {
   runtimeAppApi = createRuntimeAppApi({
     session,
     ptyTransport,
+    forwardTerminalReplies: options.forwardTerminalReplies,
     inputHandler: inputHandler!,
     ptyInputRuntime,
     interaction: runtimeInteraction,

--- a/src/runtime/create-runtime/runtime-app-api.ts
+++ b/src/runtime/create-runtime/runtime-app-api.ts
@@ -76,6 +76,7 @@ type LifecycleThemeRuntime = {
 type CreateRuntimeAppApiOptions = {
   session: ResttyAppSession;
   ptyTransport: PtyTransport;
+  forwardTerminalReplies?: boolean;
   inputHandler: InputHandler;
   ptyInputRuntime: PtyInputRuntime;
   interaction: RuntimeInteraction;
@@ -131,6 +132,7 @@ export function createRuntimeAppApi(options: CreateRuntimeAppApiOptions): Runtim
   const {
     session,
     ptyTransport,
+    forwardTerminalReplies = true,
     inputHandler,
     ptyInputRuntime,
     interaction,
@@ -270,6 +272,7 @@ export function createRuntimeAppApi(options: CreateRuntimeAppApiOptions): Runtim
   function flushWasmOutputToPty() {
     const shared = readState();
     if (!shared.wasm || !shared.wasmHandle) return;
+    if (!forwardTerminalReplies) return;
     if (!ptyTransport.isConnected()) return;
 
     let iterations = 0;

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -306,6 +306,14 @@ export type ResttyAppOptions = {
   /** PTY transport layer for terminal I/O. */
   ptyTransport?: PtyTransport;
   /**
+   * Forward terminal-generated reply bytes (for example DSR/DA responses)
+   * back to the PTY transport. Enabled by default.
+   *
+   * Set this to false when another terminal instance is the authoritative
+   * server-side emulator and the frontend should behave as a passive renderer.
+   */
+  forwardTerminalReplies?: boolean;
+  /**
    * Optional hook to transform or suppress terminal/program input
    * before it is written to the terminal core.
    */

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,0 +1,33 @@
+import type { Terminal, TerminalAddon } from "./headless";
+
+export type SerializeOptions = {
+  includeHardReset?: boolean;
+};
+
+const HARD_RESET_SEQUENCE = "\u001bc";
+
+export class SerializeAddon implements TerminalAddon {
+  private terminal: Terminal | null = null;
+
+  public activate(terminal: Terminal): void {
+    this.terminal = terminal;
+  }
+
+  public serialize(options: SerializeOptions = {}): string {
+    if (!this.terminal) {
+      return "";
+    }
+    const serialized = this.terminal.serializeReplay();
+    if (!serialized) {
+      return "";
+    }
+    if (options.includeHardReset === false || serialized.startsWith(HARD_RESET_SEQUENCE)) {
+      return serialized;
+    }
+    return `${HARD_RESET_SEQUENCE}${serialized}`;
+  }
+
+  public dispose(): void {
+    this.terminal = null;
+  }
+}

--- a/tests/headless-serialize.test.ts
+++ b/tests/headless-serialize.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test";
+import { Terminal } from "../src/headless";
+import { SerializeAddon } from "../src/serialize";
+
+test("SerializeAddon returns a reconnect-safe replay journal", async () => {
+  const terminal = new Terminal({ cols: 12, rows: 4 });
+  const serializeAddon = new SerializeAddon();
+  terminal.loadAddon(serializeAddon);
+
+  terminal.write("hello");
+  terminal.writeln(" world");
+  await terminal.whenIdle();
+
+  expect(serializeAddon.serialize()).toBe("\u001bchello world\r\n");
+
+  terminal.dispose();
+  await terminal.whenIdle();
+});
+
+test("hard reset compacts earlier journal history", async () => {
+  const terminal = new Terminal({ cols: 12, rows: 4 });
+  const serializeAddon = new SerializeAddon();
+  terminal.loadAddon(serializeAddon);
+
+  terminal.write("before");
+  terminal.reset();
+  terminal.write("after");
+  await terminal.whenIdle();
+
+  expect(serializeAddon.serialize({ includeHardReset: false })).toBe("\u001bcafter");
+
+  terminal.dispose();
+  await terminal.whenIdle();
+});
+
+test("resize updates the public terminal dimensions", async () => {
+  const terminal = new Terminal({ cols: 10, rows: 2 });
+  const resizeEvents: Array<{ cols: number; rows: number }> = [];
+  terminal.onResize((size) => {
+    resizeEvents.push(size);
+  });
+
+  terminal.resize(120, 33);
+  await terminal.whenIdle();
+
+  expect(terminal.cols).toBe(120);
+  expect(terminal.rows).toBe(33);
+  expect(resizeEvents).toEqual([{ cols: 120, rows: 33 }]);
+
+  terminal.dispose();
+  await terminal.whenIdle();
+});


### PR DESCRIPTION
## Summary
- add a headless terminal API backed by Restty WASM with a durable replay journal
- add a serialize addon for reconnect-safe terminal snapshots
- export CommonJS and ESM entrypoints for headless and serialize usage
- add an option to disable forwarding terminal-generated replies so a backend headless instance can be authoritative

## Testing
- bun test ./tests/headless-serialize.test.ts
- bun run build