### PR TITLE
fix: add missing font labels on cdn sources and widen emoji codepoint detection

### DIFF
--- a/src/fonts/manager/classification.ts
+++ b/src/fonts/manager/classification.ts
@@ -1,12 +1,26 @@
 import type { FontEntry, FontScaleOverride } from "../types";
 
-const SYMBOL_FONT_HINTS = [/symbols nerd font/i, /noto sans symbols/i, /apple symbols/i, /symbola/i];
-const NERD_SYMBOL_FONT_HINTS = [/symbols nerd font/i, /nerd fonts symbols/i];
+const SYMBOL_FONT_HINTS = [
+  /symbols nerd font/i,
+  /symbolsnerd/i,
+  /noto sans symbols/i,
+  /notosanssymbols/i,
+  /apple symbols/i,
+  /symbola/i,
+];
+const NERD_SYMBOL_FONT_HINTS = [
+  /symbols nerd font/i,
+  /symbolsnerd/i,
+  /nerd fonts symbols/i,
+  /nerdfontssymbols/i,
+];
 const COLOR_EMOJI_FONT_HINTS = [
   /apple color emoji/i,
   /noto color emoji/i,
+  /notocoloremoji/i,
   /segoe ui emoji/i,
   /twemoji/i,
+  /openmoji/i,
 ];
 const WIDE_FONT_HINTS = [
   /cjk/i,

--- a/src/fonts/manager/picker.ts
+++ b/src/fonts/manager/picker.ts
@@ -4,8 +4,11 @@ import { isColorEmojiFont, isNerdSymbolFont, isSymbolFont } from "./classificati
 import { fontHasGlyph } from "./entries";
 
 function isLikelyEmojiCodepoint(cp: number): boolean {
-  if (cp >= 0x1f1e6 && cp <= 0x1f1ff) return true;
-  if (cp >= 0x1f300 && cp <= 0x1faff) return true;
+  if (cp >= 0x1f1e6 && cp <= 0x1f1ff) return true; // regional indicators
+  if (cp >= 0x1f300 && cp <= 0x1faff) return true; // misc symbols & pictographs, emoticons, etc.
+  if (cp >= 0x2300 && cp <= 0x23ff) return true; // misc technical (⏱ ⌘ ⏏ etc.)
+  if (cp >= 0x2600 && cp <= 0x27bf) return true; // misc symbols + dingbats (✍ ☀ ✂ ⟳ etc.)
+  if (cp >= 0x2b50 && cp <= 0x2b55) return true; // stars, circles (⭐ ⭕ etc.)
   return false;
 }
 

--- a/src/runtime/font-sources.ts
+++ b/src/runtime/font-sources.ts
@@ -79,6 +79,7 @@ export const DEFAULT_FONT_SOURCES: ResttyFontSource[] = [
   {
     type: "url",
     url: "https://cdn.jsdelivr.net/gh/ryanoasis/nerd-fonts@v3.4.0/patched-fonts/NerdFontsSymbolsOnly/SymbolsNerdFontMono-Regular.ttf",
+    label: "Symbols Nerd Font",
   },
   // Ghostty parity on macOS: prefer system symbols/emoji when available.
   {
@@ -89,10 +90,12 @@ export const DEFAULT_FONT_SOURCES: ResttyFontSource[] = [
   {
     type: "url",
     url: "https://cdn.jsdelivr.net/gh/notofonts/noto-fonts@main/unhinted/ttf/NotoSansSymbols2/NotoSansSymbols2-Regular.ttf",
+    label: "Noto Sans Symbols 2",
   },
   {
     type: "url",
     url: "https://cdn.jsdelivr.net/gh/ChiefMikeK/ttf-symbola@master/Symbola.ttf",
+    label: "Symbola",
   },
   {
     type: "local",
@@ -117,14 +120,17 @@ export const DEFAULT_FONT_SOURCES: ResttyFontSource[] = [
   {
     type: "url",
     url: "https://cdn.jsdelivr.net/gh/googlefonts/noto-emoji@main/fonts/NotoColorEmoji.ttf",
+    label: "Noto Color Emoji",
   },
   {
     type: "url",
     url: "https://cdn.jsdelivr.net/gh/hfg-gmuend/openmoji@master/font/OpenMoji-black-glyf/OpenMoji-black-glyf.ttf",
+    label: "OpenMoji",
   },
   {
     type: "url",
     url: "https://cdn.jsdelivr.net/gh/notofonts/noto-cjk@main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf",
+    label: "Noto Sans CJK SC",
   },
 ];
 


### PR DESCRIPTION
## problem

the default font preset loads emoji and symbol fonts from cdn, but several of those entries are missing their `label` field. the font picker in `picker.ts` classifies fonts by checking `entry.label` against regex hint lists — `isColorEmojiFont()`, `isSymbolFont()`, `isNerdSymbolFont()` all bail early with `false` when the label is falsy.

so what happens is: noto color emoji loads fine from the cdn, but when the picker encounters an emoji character like ✍️ (U+270D + U+FE0F), it correctly detects the VS-16 and sets `presentation = "emoji"`, then searches for a `ColorEmojiFont` — which returns `-1` because the loaded noto color emoji entry has no label matching `/noto color emoji/i`. the character falls through to the generic "try any font" path and gets rendered with whatever glyph the primary monospace font has at that codepoint, which is usually wrong.

there's a secondary issue with `sourceLabelFromUrl()` — when no label is provided, it derives one from the filename (e.g. `"NotoColorEmoji.ttf"`). but the classification regex `/noto color emoji/i` doesn't match that either because there are no spaces. so even the fallback label doesn't help.

this is the root cause behind the rendering issues described in #14. it also contributes to visual artifacts like those in #13, where wrong-width glyphs cause column drift and ghosting.

## what this changes

### `src/runtime/font-sources.ts`

added `label` to all cdn font source entries that were missing one:

- `"Symbols Nerd Font"` for the nerd symbols cdn fallback
- `"Noto Sans Symbols 2"` and `"Symbola"` for the symbol cdn fonts
- `"Noto Color Emoji"` and `"OpenMoji"` for the emoji cdn fonts  
- `"Noto Sans CJK SC"` for the cjk cdn font

these labels now match the existing regex patterns in `classification.ts`.

### `src/fonts/manager/classification.ts`

added concatenated-name regex patterns to catch url-derived labels from user-provided font sources (where users don't set explicit labels):

- `COLOR_EMOJI_FONT_HINTS`: added `/notocoloremoji/i` and `/openmoji/i`
- `SYMBOL_FONT_HINTS`: added `/symbolsnerd/i` and `/notosanssymbols/i`
- `NERD_SYMBOL_FONT_HINTS`: added `/symbolsnerd/i` and `/nerdfontssymbols/i`

this covers cases where someone passes `{ type: "url", url: "https://example.com/NotoColorEmoji.ttf" }` without a label — `sourceLabelFromUrl` produces `"NotoColorEmoji.ttf"` which now matches `/notocoloremoji/i`.

### `src/fonts/manager/picker.ts`

expanded `isLikelyEmojiCodepoint()` to cover three additional unicode ranges that contain characters commonly rendered as emoji:

- `U+2300–23FF` misc technical (⏱ ⌘ ⏏ etc.)
- `U+2600–27BF` misc symbols + dingbats (✍ ☀ ✂ ⟳ etc.)
- `U+2B50–2B55` supplemental symbols (⭐ ⭕ etc.)

these are the ranges that trip up terminal status lines and cli tools the most. without this, characters like ✍ (U+270D) that don't have VS-16 appended default to `presentation = "auto"` and skip the emoji font search entirely.

## testing

ran the existing test suite — all font-fallback-parity and symbol-rendering tests pass. the 6 failures in the full suite are pre-existing missing-dependency errors (`text-shaper`, `wgpu-polyfill`) unrelated to this change.

verified the fix logic by tracing the code path:
1. `"Noto Color Emoji"` label → `isColorEmojiFont()` returns `true` → emoji characters correctly route to this font
2. `"Symbols Nerd Font"` label → `isNerdSymbolFont()` returns `true` → nerd symbols correctly route
3. `U+270D` (✍) → `isLikelyEmojiCodepoint()` returns `true` → picker searches emoji fonts even without VS-16

relates to #14, #13