### PR TITLE
fix: sync wasmHandle to closure before applyTheme in initWasmHarness

### DIFF
--- a/src/runtime/create-runtime/runtime-app-api.ts
+++ b/src/runtime/create-runtime/runtime-app-api.ts
@@ -523,12 +523,16 @@ export function createRuntimeAppApi(options: CreateRuntimeAppApiOptions): Runtim
       }
       const canvas = getCanvas();
       instance.setPixelSize(wasmHandle, canvas.width, canvas.height);
+      // Sync wasmHandle to closure BEFORE applying theme,
+      // otherwise applyTheme can't push palette to WASM.
+      writeState({ wasmHandle });
       const activeTheme = lifecycleThemeSizeRuntime.getActiveTheme();
       if (activeTheme) {
         applyTheme(activeTheme, activeTheme.name ?? "cached theme");
+      } else {
+        instance.renderUpdate(wasmHandle);
       }
-      instance.renderUpdate(wasmHandle);
-      writeState({ wasmHandle, needsRender: true });
+      writeState({ needsRender: true });
       handleSearchWasmReset();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Problem

During terminal initialization, `initWasmHarness()` creates a WASM instance and
obtains a `wasmHandle`. If an active theme exists (e.g., from system theme
auto-detection or an initially configured theme), `applyTheme()` is called to
push palette colors to the WASM module. However, `applyTheme()` internally
checks `getWasmHandle()` — which reads the module-level `wasmHandle` variable
via closure — to decide whether to perform the WASM palette push.

Because `writeState({ wasmHandle })` was called **after** `applyTheme()`, the
closure still returned `0`, causing the entire WASM color push (foreground,
background, cursor, and 16-color ANSI palette) to be silently skipped.

**Result:** The initial theme's colors never took effect on the WASM-rendered
terminal; it displayed default/incorrect colors until a subsequent theme change
triggered another `applyTheme()` call.

## Root Cause

In `src/runtime/create-runtime/runtime-app-api.ts`, the `initWasmHarness()`
function wrote `wasmHandle` to shared state too late:

```
writeState({ wasmHandle });  // ← was after applyTheme()
```

The `getWasmHandle` closure in `create-runtime.ts` (line 796: `() => wasmHandle`)
is updated only when `writeState({ wasmHandle })` is called, due to the
destructuring assignment in `writeRuntimeAppApiState`.

## Fix

1. **Move `writeState({ wasmHandle })` before `applyTheme()`** so the closure
   has the correct handle when `applyTheme` checks it.
2. **Move the unconditional `instance.renderUpdate(wasmHandle)` into the `else`
   branch** — `applyTheme()` already calls `wasm.renderUpdate(wasmHandle)`
   internally after pushing colors, so calling it again was redundant.

## Validation

I switched to pnpm and vitest in my fork, and all tests passed without any new lint or format issues.