### PR TITLE
fix(fonts): align CJK fallback baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This project follows SemVer. While restty is pre-1.0, breaking public API change
 
 ### Docs
 
+## [0.2.2] - 2026-07-16
+
+### Fixes
+
+- Kept ordinary fallback text on the primary font baseline after fallback scaling, eliminating the roughly one-pixel downward shift for CJK glyphs introduced in 0.2.1.
+
 ## [0.2.1] - 2026-07-16
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restty",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Browser terminal rendering library powered by WASM, WebGPU/WebGL2, and TypeScript text shaping.",
   "keywords": [
     "ansi",

--- a/src/runtime/create-runtime/render-tick-webgl-context.ts
+++ b/src/runtime/create-runtime/render-tick-webgl-context.ts
@@ -1,7 +1,7 @@
 import type { Color, WebGLState } from "../../renderer";
 import { fallbackEmScale, type Font, type FontEntry } from "../../fonts";
 import type { GlyphConstraintMeta } from "../fonts/atlas-builder";
-import { resolveWideFallbackScale } from "../fonts/fallback-layout";
+import { resolveFallbackBaselineAdjust, resolveWideFallbackScale } from "../fonts/fallback-layout";
 import type { GlyphQueueItem } from "./render-tick-webgpu.types";
 import type { WebGLTickContext, WebGLTickDeps } from "./render-tick-webgl.types";
 
@@ -261,28 +261,6 @@ export function buildWebGLTickContext(
     }
     return 1;
   };
-  const fallbackMetricAnchorUnits = (
-    primary: FontEntry | undefined,
-    entry: FontEntry | undefined,
-  ): { primary: number; fallback: number } | null => {
-    if (!primary?.font || !entry?.font) return null;
-    const metricOrder: FallbackScaleMetric[] = [
-      "ic_width",
-      "ex_height",
-      "cap_height",
-      "line_height",
-    ];
-    for (let i = 0; i < metricOrder.length; i += 1) {
-      const metric = metricOrder[i];
-      const primaryMetric = resolveFallbackMetric(primary.font, metric);
-      const fallbackMetric = resolveFallbackMetric(entry.font, metric);
-      if (primaryMetric > 0 && fallbackMetric > 0) {
-        return { primary: primaryMetric, fallback: fallbackMetric };
-      }
-    }
-    return null;
-  };
-
   const baseScaleByFont = fontState.fonts.map((entry, idx) => {
     if (!entry?.font) return primaryScale;
     if (idx === 0) return primaryScale;
@@ -336,13 +314,13 @@ export function buildWebGLTickContext(
     if (!entry?.font || idx === 0 || !primaryEntry?.font) return 0;
     const scale = scaleByFont[idx] ?? primaryScale;
     const preserveNaturalSymbolScale = isSymbolFont(entry) && !isAppleSymbolsFont(entry);
-    if (!preserveNaturalSymbolScale && !isColorEmojiFont(entry)) {
-      const metricAnchor = fallbackMetricAnchorUnits(primaryEntry, entry);
-      if (metricAnchor) {
-        return metricAnchor.primary * primaryScale - metricAnchor.fallback * scale;
-      }
-    }
-    return primaryEntry.font.ascender * primaryScale - entry.font.ascender * scale;
+    return resolveFallbackBaselineAdjust({
+      primaryScale,
+      fallbackScale: scale,
+      primaryAscender: primaryEntry.font.ascender,
+      fallbackAscender: entry.font.ascender,
+      regularTextFallback: !preserveNaturalSymbolScale && !isColorEmojiFont(entry),
+    });
   });
 
   const nerdMetrics = buildNerdMetrics(

--- a/src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts
+++ b/src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts
@@ -1,7 +1,7 @@
 import type { Color } from "../../renderer";
 import { fallbackEmScale, type Font, type FontEntry } from "../../fonts";
 import type { GlyphConstraintMeta } from "../fonts/atlas-builder";
-import { resolveWideFallbackScale } from "../fonts/fallback-layout";
+import { resolveFallbackBaselineAdjust, resolveWideFallbackScale } from "../fonts/fallback-layout";
 import { resolveLigatureRun, resolveRenderableLigatureRun } from "./ligature-runs";
 import type { CollectWebGPUCellPassParams, GlyphQueueItem } from "./render-tick-webgpu.types";
 import {
@@ -174,28 +174,6 @@ export function collectWebGPUCellPass(params: CollectWebGPUCellPassParams) {
     }
     return 1;
   };
-  const fallbackMetricAnchorUnits = (
-    primary: FontEntry | undefined,
-    entry: FontEntry | undefined,
-  ): { primary: number; fallback: number } | null => {
-    if (!primary?.font || !entry?.font) return null;
-    const metricOrder: FallbackScaleMetric[] = [
-      "ic_width",
-      "ex_height",
-      "cap_height",
-      "line_height",
-    ];
-    for (let i = 0; i < metricOrder.length; i += 1) {
-      const metric = metricOrder[i];
-      const primaryMetric = resolveFallbackMetric(primary.font, metric);
-      const fallbackMetric = resolveFallbackMetric(entry.font, metric);
-      if (primaryMetric > 0 && fallbackMetric > 0) {
-        return { primary: primaryMetric, fallback: fallbackMetric };
-      }
-    }
-    return null;
-  };
-
   const baseScaleByFont = fontState.fonts.map((entry, idx) => {
     if (!entry?.font) return primaryScale;
     if (idx === 0) return primaryScale;
@@ -249,13 +227,13 @@ export function collectWebGPUCellPass(params: CollectWebGPUCellPassParams) {
     if (!entry?.font || idx === 0 || !primaryEntry?.font) return 0;
     const scale = scaleByFont[idx] ?? primaryScale;
     const preserveNaturalSymbolScale = isSymbolFont(entry) && !isAppleSymbolsFont(entry);
-    if (!preserveNaturalSymbolScale && !isColorEmojiFont(entry)) {
-      const metricAnchor = fallbackMetricAnchorUnits(primaryEntry, entry);
-      if (metricAnchor) {
-        return metricAnchor.primary * primaryScale - metricAnchor.fallback * scale;
-      }
-    }
-    return primaryEntry.font.ascender * primaryScale - entry.font.ascender * scale;
+    return resolveFallbackBaselineAdjust({
+      primaryScale,
+      fallbackScale: scale,
+      primaryAscender: primaryEntry.font.ascender,
+      fallbackAscender: entry.font.ascender,
+      regularTextFallback: !preserveNaturalSymbolScale && !isColorEmojiFont(entry),
+    });
   });
 
   const nerdMetrics = buildNerdMetrics(

--- a/src/runtime/fonts/fallback-layout.ts
+++ b/src/runtime/fonts/fallback-layout.ts
@@ -32,3 +32,19 @@ export function resolveFallbackGlyphCenterX(options: FallbackGlyphCenterOptions)
   }
   return cellX + (cellWidth - glyphWidth) * 0.5;
 }
+
+export type FallbackBaselineAdjustOptions = {
+  primaryScale: number;
+  fallbackScale: number;
+  primaryAscender: number;
+  fallbackAscender: number;
+  regularTextFallback: boolean;
+};
+
+/** Resolve the vertical offset applied to a fallback glyph baseline. */
+export function resolveFallbackBaselineAdjust(options: FallbackBaselineAdjustOptions): number {
+  const { primaryScale, fallbackScale, primaryAscender, fallbackAscender, regularTextFallback } =
+    options;
+  if (regularTextFallback) return 0;
+  return primaryAscender * primaryScale - fallbackAscender * fallbackScale;
+}

--- a/tests/fallback-font-layout.test.ts
+++ b/tests/fallback-font-layout.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import {
+  resolveFallbackBaselineAdjust,
   resolveFallbackGlyphCenterX,
   resolveWideFallbackScale,
 } from "../src/runtime/fonts/fallback-layout";
@@ -26,4 +27,20 @@ test("wide fallback glyphs are centered across their occupied cells", () => {
   });
 
   expect(x).toBeCloseTo(41.6);
+});
+
+test("regular CJK fallback text stays on the primary baseline", () => {
+  // Bundled Fira Code + Noto Sans CJK at the default 18px height. The old
+  // metric-anchor calculation produced a visible 1.1475px downward offset.
+  expect(1053 * 0.0075 - 543 * (18 / 1448)).toBeCloseTo(1.1475);
+
+  const baselineAdjust = resolveFallbackBaselineAdjust({
+    primaryScale: 0.0075,
+    fallbackScale: 18 / 1448,
+    primaryAscender: 1800,
+    fallbackAscender: 1160,
+    regularTextFallback: true,
+  });
+
+  expect(baselineAdjust).toBe(0);
 });


### PR DESCRIPTION
## Summary

- keep ordinary fallback text on the primary font baseline after fallback scaling
- share the baseline adjustment rule between WebGPU and WebGL2
- add regression coverage using the bundled Fira Code and Noto CJK metrics
- prepare `restty@0.2.2` as a regression patch

## Root cause

After the 0.2.1 no-upscale fix, the fallback scale could be reduced by the line-height clamp while the old metric-anchor offset was still applied. With the bundled default font metrics that calculation adds `+1.1475px`, shifting CJK glyphs downward even though bitmap bearings are already relative to the common baseline.

## Validation

- 314 CI-safe tests, 0 failures
- `bun run format:check`
- `bun run lint`
- `bun run build:types`
- `bun run build`
- `bun run playground:build`
- release-note extraction for 0.2.2

Follow-up to #24.