### PR TITLE
fix(fonts): preserve wide CJK em scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This project follows SemVer. While restty is pre-1.0, breaking public API change
 
 ### Docs
 
+## [0.2.3] - 2026-07-16
+
+### Fixes
+
+- Rendered wide CJK fallbacks at the primary font's em size instead of shrinking them to the fallback face's taller line metrics, reducing excessive spacing while retaining two-cell fit and centered placement.
+
 ## [0.2.2] - 2026-07-16
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restty",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Browser terminal rendering library powered by WASM, WebGPU/WebGL2, and TypeScript text shaping.",
   "keywords": [
     "ansi",

--- a/src/runtime/create-runtime/render-tick-webgl-context.ts
+++ b/src/runtime/create-runtime/render-tick-webgl-context.ts
@@ -1,7 +1,7 @@
 import type { Color, WebGLState } from "../../renderer";
 import { fallbackEmScale, type Font, type FontEntry } from "../../fonts";
 import type { GlyphConstraintMeta } from "../fonts/atlas-builder";
-import { resolveFallbackBaselineAdjust, resolveWideFallbackScale } from "../fonts/fallback-layout";
+import { resolveFallbackBaselineAdjust, resolveFallbackTextScale } from "../fonts/fallback-layout";
 import type { GlyphQueueItem } from "./render-tick-webgpu.types";
 import type { WebGLTickContext, WebGLTickDeps } from "./render-tick-webgl.types";
 
@@ -284,22 +284,23 @@ export function buildWebGLTickContext(
     }
     if (isColorEmojiFont(entry)) return baseScale;
     const metricAdjust = clamp(fallbackScaleAdjustment(primaryEntry, entry), 1, 2);
-    let adjustedScale = baseScale * metricAdjust;
     const maxSpan = fontMaxCellSpan(entry);
-    if (maxSpan > 1) {
-      const advanceUnits = fontAdvanceUnits(entry, shapeClusterWithFont);
-      adjustedScale = resolveWideFallbackScale({
-        scale: adjustedScale,
-        advanceUnits,
-        cellWidth: cellW,
-        maxSpan,
-      });
-    }
-    const adjustedHeightPx = fontHeightUnits(entry.font) * adjustedScale;
-    if (adjustedHeightPx > lineHeight && adjustedHeightPx > 0) {
-      adjustedScale *= lineHeight / adjustedHeightPx;
-    }
-    return adjustedScale;
+    const advanceUnits =
+      maxSpan > 1
+        ? resolveFallbackMetric(entry.font, "ic_width") ||
+          fontAdvanceUnits(entry, shapeClusterWithFont)
+        : 0;
+    const emScale = fallbackEmScale(primaryEntry?.font, primaryScale, entry.font);
+    return resolveFallbackTextScale({
+      baseScale,
+      primaryEmScale: emScale > 0 ? emScale * fontScaleOverride(entry, FONT_SCALE_OVERRIDES) : 0,
+      metricAdjust,
+      advanceUnits,
+      cellWidth: cellW,
+      maxSpan,
+      fontHeightUnits: fontHeightUnits(entry.font),
+      lineHeight,
+    });
   });
 
   const bitmapScaleByFont = fontState.fonts.map((entry, idx) => {

--- a/src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts
+++ b/src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts
@@ -1,7 +1,7 @@
 import type { Color } from "../../renderer";
 import { fallbackEmScale, type Font, type FontEntry } from "../../fonts";
 import type { GlyphConstraintMeta } from "../fonts/atlas-builder";
-import { resolveFallbackBaselineAdjust, resolveWideFallbackScale } from "../fonts/fallback-layout";
+import { resolveFallbackBaselineAdjust, resolveFallbackTextScale } from "../fonts/fallback-layout";
 import { resolveLigatureRun, resolveRenderableLigatureRun } from "./ligature-runs";
 import type { CollectWebGPUCellPassParams, GlyphQueueItem } from "./render-tick-webgpu.types";
 import {
@@ -197,22 +197,23 @@ export function collectWebGPUCellPass(params: CollectWebGPUCellPassParams) {
     }
     if (isColorEmojiFont(entry)) return baseScale;
     const metricAdjust = clamp(fallbackScaleAdjustment(primaryEntry, entry), 1, 2);
-    let adjustedScale = baseScale * metricAdjust;
     const maxSpan = fontMaxCellSpan(entry);
-    if (maxSpan > 1) {
-      const advanceUnits = fontAdvanceUnits(entry, shapeClusterWithFont);
-      adjustedScale = resolveWideFallbackScale({
-        scale: adjustedScale,
-        advanceUnits,
-        cellWidth: cellW,
-        maxSpan,
-      });
-    }
-    const adjustedHeightPx = fontHeightUnits(entry.font) * adjustedScale;
-    if (adjustedHeightPx > lineHeight && adjustedHeightPx > 0) {
-      adjustedScale *= lineHeight / adjustedHeightPx;
-    }
-    return adjustedScale;
+    const advanceUnits =
+      maxSpan > 1
+        ? resolveFallbackMetric(entry.font, "ic_width") ||
+          fontAdvanceUnits(entry, shapeClusterWithFont)
+        : 0;
+    const emScale = fallbackEmScale(primaryEntry?.font, primaryScale, entry.font);
+    return resolveFallbackTextScale({
+      baseScale,
+      primaryEmScale: emScale > 0 ? emScale * fontScaleOverride(entry, FONT_SCALE_OVERRIDES) : 0,
+      metricAdjust,
+      advanceUnits,
+      cellWidth: cellW,
+      maxSpan,
+      fontHeightUnits: fontHeightUnits(entry.font),
+      lineHeight,
+    });
   });
 
   const bitmapScaleByFont = fontState.fonts.map((entry, idx) => {

--- a/src/runtime/fonts/fallback-layout.ts
+++ b/src/runtime/fonts/fallback-layout.ts
@@ -15,6 +15,43 @@ export function resolveWideFallbackScale(options: WideFallbackScaleOptions): num
   return scale * widthAdjust;
 }
 
+export type FallbackTextScaleOptions = {
+  baseScale: number;
+  primaryEmScale: number;
+  metricAdjust: number;
+  advanceUnits: number;
+  cellWidth: number;
+  maxSpan: number;
+  fontHeightUnits: number;
+  lineHeight: number;
+};
+
+/** Resolve the raster scale used for an ordinary fallback text face. */
+export function resolveFallbackTextScale(options: FallbackTextScaleOptions): number {
+  const {
+    baseScale,
+    primaryEmScale,
+    metricAdjust,
+    advanceUnits,
+    cellWidth,
+    maxSpan,
+    fontHeightUnits,
+    lineHeight,
+  } = options;
+  if (maxSpan > 1 && primaryEmScale > 0) {
+    return resolveWideFallbackScale({
+      scale: primaryEmScale,
+      advanceUnits,
+      cellWidth,
+      maxSpan,
+    });
+  }
+  let scale = baseScale * metricAdjust;
+  const heightPx = fontHeightUnits * scale;
+  if (heightPx > lineHeight && heightPx > 0) scale *= lineHeight / heightPx;
+  return scale;
+}
+
 export type FallbackGlyphCenterOptions = {
   cellX: number;
   cellWidth: number;

--- a/tests/fallback-font-layout.test.ts
+++ b/tests/fallback-font-layout.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import {
   resolveFallbackBaselineAdjust,
   resolveFallbackGlyphCenterX,
+  resolveFallbackTextScale,
   resolveWideFallbackScale,
 } from "../src/runtime/fonts/fallback-layout";
 
@@ -14,6 +15,22 @@ test("wide CJK fallbacks keep their natural em scale", () => {
   });
 
   expect(scale).toBeCloseTo(0.016, 5);
+});
+
+test("wide CJK fallbacks use the primary em instead of their taller line metrics", () => {
+  const scale = resolveFallbackTextScale({
+    baseScale: 18 / 1448,
+    primaryEmScale: 18 / 1320,
+    metricAdjust: 550 / 543,
+    advanceUnits: 1000,
+    cellWidth: 8,
+    maxSpan: 2,
+    fontHeightUnits: 1448,
+    lineHeight: 18,
+  });
+
+  expect(scale).toBeCloseTo(18 / 1320, 6);
+  expect(1000 * scale).toBeCloseTo(13.63636);
 });
 
 test("wide fallback glyphs are centered across their occupied cells", () => {

--- a/tests/symbol-rendering.test.ts
+++ b/tests/symbol-rendering.test.ts
@@ -136,7 +136,7 @@ test("symbol constraints remain table-driven without per-codepoint overrides", (
   expect(resolveSymbolConstraint(0x15e3)).toBeNull();
 });
 
-test("fallback font scaling uses Ghostty-style metric adjustment with wide-font width correction", () => {
+test("fallback font scaling routes primary-em wide faces through the shared resolver", () => {
   const webgpuSource = readFileSync(
     join(process.cwd(), "src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts"),
     "utf8",
@@ -151,9 +151,9 @@ test("fallback font scaling uses Ghostty-style metric adjustment with wide-font 
   const upscaleOnlyPattern = /clamp\(fallbackScaleAdjustment\(primaryEntry, entry\), 1, 2\)/g;
   expect((webgpuSource.match(upscaleOnlyPattern) ?? []).length).toBe(1);
   expect((webglSource.match(upscaleOnlyPattern) ?? []).length).toBe(1);
-  const wideOnlyPattern = /if \(maxSpan > 1\) \{/g;
-  expect((webgpuSource.match(wideOnlyPattern) ?? []).length).toBe(1);
-  expect((webglSource.match(wideOnlyPattern) ?? []).length).toBe(1);
+  const sharedScalePattern = /resolveFallbackTextScale\(\{/g;
+  expect((webgpuSource.match(sharedScalePattern) ?? []).length).toBe(1);
+  expect((webglSource.match(sharedScalePattern) ?? []).length).toBe(1);
 });
 
 test("fallback glyph clamp avoids width bbox shrinking in emit paths", () => {


### PR DESCRIPTION
## Summary

- render wide CJK fallback text at the primary font's em size
- shrink only when the ideographic advance exceeds the available two-cell span
- avoid shrinking valid CJK outlines because the fallback face has taller line metrics
- share the scale resolver between WebGPU and WebGL2 and prepare `restty@0.2.3`

## Root cause

At the default 18px setting, JetBrains Mono creates two-cell spans of 16px. Noto CJK was being clamped from the primary-em 13.6364px advance to 12.4309px because its 1448-unit line metrics are taller than JetBrains Mono's 1320-unit metrics. Centering that undersized bitmap made the inter-character gaps visibly excessive.

## Validation

- exact JetBrains/Noto regression: 12.4309px before, 13.6364px after
- 315 CI-safe tests, 0 failures
- `bun run format:check`
- `bun run lint`
- `bun run build:types`
- `bun run build`
- `bun run playground:build`
- release-note extraction for 0.2.3

Follow-up to #24.