### PR TITLE
fix(fonts): match Ghostty CJK width scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This project follows SemVer. While restty is pre-1.0, breaking public API change
 
 ### Docs
 
+## [0.2.4] - 2026-07-16
+
+### Fixes
+
+- Matched Ghostty's default em-normalized `ic_width` adjustment for fallback fonts, using the primary printable-ASCII box and the fallback ideograph advance to remove excessive spacing around CJK glyphs while preserving their shared baseline and two-cell bound.
+
 ## [0.2.3] - 2026-07-16
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restty",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Browser terminal rendering library powered by WASM, WebGPU/WebGL2, and TypeScript text shaping.",
   "keywords": [
     "ansi",

--- a/src/runtime/create-runtime/render-tick-webgl-context.ts
+++ b/src/runtime/create-runtime/render-tick-webgl-context.ts
@@ -1,7 +1,12 @@
 import type { Color, WebGLState } from "../../renderer";
-import { fallbackEmScale, type Font, type FontEntry } from "../../fonts";
+import { fallbackEmScale } from "../../fonts";
 import type { GlyphConstraintMeta } from "../fonts/atlas-builder";
-import { resolveFallbackBaselineAdjust, resolveFallbackTextScale } from "../fonts/fallback-layout";
+import {
+  resolveFallbackBaselineAdjust,
+  resolveFallbackIcWidth,
+  resolveFallbackScaleAdjustment,
+  resolveFallbackTextScale,
+} from "../fonts/fallback-layout";
 import type { GlyphQueueItem } from "./render-tick-webgpu.types";
 import type { WebGLTickContext, WebGLTickDeps } from "./render-tick-webgl.types";
 
@@ -210,57 +215,6 @@ export function buildWebGLTickContext(
   const fgColorCache = new Map<number, Color>();
   const bgColorCache = new Map<number, Color>();
   const ulColorCache = new Map<number, Color>();
-  type FallbackScaleMetric = "ic_width" | "ex_height" | "cap_height" | "line_height";
-  const resolveFallbackMetric = (font: Font | null | undefined, metric: FallbackScaleMetric) => {
-    if (!font) return 0;
-    if (metric === "ic_width") {
-      const glyphId = font.glyphIdForChar("水");
-      if (!glyphId) return 0;
-      const advance = font.advanceWidth(glyphId);
-      if (!Number.isFinite(advance) || advance <= 0) return 0;
-      const bounds = font.getGlyphBounds(glyphId);
-      // If outline width exceeds advance, ic-width is likely unreliable for scaling.
-      if (
-        bounds &&
-        Number.isFinite(bounds.xMax - bounds.xMin) &&
-        bounds.xMax - bounds.xMin > advance
-      ) {
-        return 0;
-      }
-      return advance;
-    }
-    if (metric === "ex_height") {
-      const exHeight = font.os2?.sxHeight ?? 0;
-      return Number.isFinite(exHeight) && exHeight > 0 ? exHeight : 0;
-    }
-    if (metric === "cap_height") {
-      const capHeight = font.os2?.sCapHeight ?? 0;
-      return Number.isFinite(capHeight) && capHeight > 0 ? capHeight : 0;
-    }
-    const lineHeightUnits = font.height;
-    return Number.isFinite(lineHeightUnits) && lineHeightUnits > 0 ? lineHeightUnits : 0;
-  };
-  const fallbackScaleAdjustment = (
-    primary: FontEntry | undefined,
-    entry: FontEntry | undefined,
-  ): number => {
-    if (!primary?.font || !entry?.font) return 1;
-    const metricOrder: FallbackScaleMetric[] = [
-      "ic_width",
-      "ex_height",
-      "cap_height",
-      "line_height",
-    ];
-    for (let i = 0; i < metricOrder.length; i += 1) {
-      const metric = metricOrder[i];
-      const primaryMetric = resolveFallbackMetric(primary.font, metric);
-      const fallbackMetric = resolveFallbackMetric(entry.font, metric);
-      if (primaryMetric <= 0 || fallbackMetric <= 0) continue;
-      const factor = primaryMetric / fallbackMetric;
-      if (Number.isFinite(factor) && factor > 0) return factor;
-    }
-    return 1;
-  };
   const baseScaleByFont = fontState.fonts.map((entry, idx) => {
     if (!entry?.font) return primaryScale;
     if (idx === 0) return primaryScale;
@@ -283,12 +237,11 @@ export function buildWebGLTickContext(
       return baseScale;
     }
     if (isColorEmojiFont(entry)) return baseScale;
-    const metricAdjust = clamp(fallbackScaleAdjustment(primaryEntry, entry), 1, 2);
+    const metricAdjust = resolveFallbackScaleAdjustment(primaryEntry?.font, entry.font);
     const maxSpan = fontMaxCellSpan(entry);
     const advanceUnits =
       maxSpan > 1
-        ? resolveFallbackMetric(entry.font, "ic_width") ||
-          fontAdvanceUnits(entry, shapeClusterWithFont)
+        ? resolveFallbackIcWidth(entry.font) || fontAdvanceUnits(entry, shapeClusterWithFont)
         : 0;
     const emScale = fallbackEmScale(primaryEntry?.font, primaryScale, entry.font);
     return resolveFallbackTextScale({

--- a/src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts
+++ b/src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts
@@ -1,7 +1,12 @@
 import type { Color } from "../../renderer";
-import { fallbackEmScale, type Font, type FontEntry } from "../../fonts";
+import { fallbackEmScale } from "../../fonts";
 import type { GlyphConstraintMeta } from "../fonts/atlas-builder";
-import { resolveFallbackBaselineAdjust, resolveFallbackTextScale } from "../fonts/fallback-layout";
+import {
+  resolveFallbackBaselineAdjust,
+  resolveFallbackIcWidth,
+  resolveFallbackScaleAdjustment,
+  resolveFallbackTextScale,
+} from "../fonts/fallback-layout";
 import { resolveLigatureRun, resolveRenderableLigatureRun } from "./ligature-runs";
 import type { CollectWebGPUCellPassParams, GlyphQueueItem } from "./render-tick-webgpu.types";
 import {
@@ -126,54 +131,6 @@ export function collectWebGPUCellPass(params: CollectWebGPUCellPassParams) {
   const mergedLigatureSkip = new Uint8Array(codepoints.length);
 
   const primaryEntry = fontState.fonts[0];
-  type FallbackScaleMetric = "ic_width" | "ex_height" | "cap_height" | "line_height";
-  const resolveFallbackMetric = (font: Font | null | undefined, metric: FallbackScaleMetric) => {
-    if (!font) return 0;
-    if (metric === "ic_width") {
-      const glyphId = font.glyphIdForChar("水");
-      if (!glyphId) return 0;
-      const advance = font.advanceWidth(glyphId);
-      if (!Number.isFinite(advance) || advance <= 0) return 0;
-      const bounds = font.getGlyphBounds(glyphId);
-      if (bounds) {
-        const width = bounds.xMax - bounds.xMin;
-        // If outline width exceeds advance, ic-width is likely unreliable for scaling.
-        if (Number.isFinite(width) && width > advance) return 0;
-      }
-      return advance;
-    }
-    if (metric === "ex_height") {
-      const exHeight = font.os2?.sxHeight ?? 0;
-      return Number.isFinite(exHeight) && exHeight > 0 ? exHeight : 0;
-    }
-    if (metric === "cap_height") {
-      const capHeight = font.os2?.sCapHeight ?? 0;
-      return Number.isFinite(capHeight) && capHeight > 0 ? capHeight : 0;
-    }
-    const lineHeightUnits = font.height;
-    return Number.isFinite(lineHeightUnits) && lineHeightUnits > 0 ? lineHeightUnits : 0;
-  };
-  const fallbackScaleAdjustment = (
-    primary: FontEntry | undefined,
-    entry: FontEntry | undefined,
-  ): number => {
-    if (!primary?.font || !entry?.font) return 1;
-    const metricOrder: FallbackScaleMetric[] = [
-      "ic_width",
-      "ex_height",
-      "cap_height",
-      "line_height",
-    ];
-    for (let i = 0; i < metricOrder.length; i += 1) {
-      const metric = metricOrder[i];
-      const primaryMetric = resolveFallbackMetric(primary.font, metric);
-      const fallbackMetric = resolveFallbackMetric(entry.font, metric);
-      if (primaryMetric <= 0 || fallbackMetric <= 0) continue;
-      const factor = primaryMetric / fallbackMetric;
-      if (Number.isFinite(factor) && factor > 0) return factor;
-    }
-    return 1;
-  };
   const baseScaleByFont = fontState.fonts.map((entry, idx) => {
     if (!entry?.font) return primaryScale;
     if (idx === 0) return primaryScale;
@@ -196,12 +153,11 @@ export function collectWebGPUCellPass(params: CollectWebGPUCellPassParams) {
       return baseScale;
     }
     if (isColorEmojiFont(entry)) return baseScale;
-    const metricAdjust = clamp(fallbackScaleAdjustment(primaryEntry, entry), 1, 2);
+    const metricAdjust = resolveFallbackScaleAdjustment(primaryEntry?.font, entry.font);
     const maxSpan = fontMaxCellSpan(entry);
     const advanceUnits =
       maxSpan > 1
-        ? resolveFallbackMetric(entry.font, "ic_width") ||
-          fontAdvanceUnits(entry, shapeClusterWithFont)
+        ? resolveFallbackIcWidth(entry.font) || fontAdvanceUnits(entry, shapeClusterWithFont)
         : 0;
     const emScale = fallbackEmScale(primaryEntry?.font, primaryScale, entry.font);
     return resolveFallbackTextScale({

--- a/src/runtime/fonts/fallback-layout.ts
+++ b/src/runtime/fonts/fallback-layout.ts
@@ -1,3 +1,131 @@
+import type { Font } from "../../fonts";
+
+type FallbackFaceMetrics = {
+  unitsPerEm: number;
+  ascender: number;
+  lineHeight: number;
+  cellWidth: number;
+  asciiHeight: number;
+  icWidth: number;
+  exHeight: number;
+  capHeight: number;
+};
+
+const fallbackFaceMetricsCache = new WeakMap<Font, FallbackFaceMetrics>();
+
+function positive(value: number | null | undefined): number {
+  return Number.isFinite(value) && (value ?? 0) > 0 ? (value ?? 0) : 0;
+}
+
+function glyphHeight(font: Font, ch: string): number {
+  const glyphId = font.glyphIdForChar(ch);
+  if (!glyphId) return 0;
+  const bounds = font.getGlyphBounds(glyphId);
+  if (!bounds) return 0;
+  return positive(bounds.yMax - bounds.yMin);
+}
+
+function measureFallbackFace(font: Font): FallbackFaceMetrics {
+  const cached = fallbackFaceMetricsCache.get(font);
+  if (cached) return cached;
+
+  let cellWidth = 0;
+  let asciiTop = 0;
+  let asciiBottom = 0;
+  for (let codepoint = 32; codepoint < 127; codepoint += 1) {
+    const glyphId = font.glyphIdForChar(String.fromCodePoint(codepoint));
+    if (!glyphId) continue;
+    cellWidth = Math.max(cellWidth, positive(font.advanceWidth(glyphId)));
+    const bounds = font.getGlyphBounds(glyphId);
+    if (!bounds) continue;
+    if (Number.isFinite(bounds.yMax)) asciiTop = Math.max(asciiTop, bounds.yMax);
+    if (Number.isFinite(bounds.yMin)) asciiBottom = Math.min(asciiBottom, bounds.yMin);
+  }
+
+  let icWidth = 0;
+  const ideographGlyphId = font.glyphIdForChar("水");
+  if (ideographGlyphId) {
+    const advance = positive(font.advanceWidth(ideographGlyphId));
+    const bounds = font.getGlyphBounds(ideographGlyphId);
+    const outlineWidth = bounds ? positive(bounds.xMax - bounds.xMin) : 0;
+    if (advance > 0 && (outlineWidth <= 0 || outlineWidth <= advance)) icWidth = advance;
+  }
+
+  const metrics = {
+    unitsPerEm: positive(font.unitsPerEm),
+    ascender: positive(font.ascender),
+    lineHeight: positive(font.height),
+    cellWidth,
+    asciiHeight: positive(asciiTop - asciiBottom),
+    icWidth,
+    exHeight: positive(font.os2?.sxHeight) || glyphHeight(font, "x"),
+    capHeight: positive(font.os2?.sCapHeight) || glyphHeight(font, "H"),
+  };
+  fallbackFaceMetricsCache.set(font, metrics);
+  return metrics;
+}
+
+function capHeight(metrics: FallbackFaceMetrics): number {
+  return metrics.capHeight || metrics.ascender * 0.75;
+}
+
+function exHeight(metrics: FallbackFaceMetrics): number {
+  return metrics.exHeight || capHeight(metrics) * 0.75;
+}
+
+function icWidth(metrics: FallbackFaceMetrics): number {
+  if (metrics.icWidth > 0) return metrics.icWidth;
+  const asciiHeight = metrics.asciiHeight || capHeight(metrics) * 1.5;
+  return Math.min(asciiHeight, metrics.cellWidth * 2);
+}
+
+function normalizedMetricFactor(
+  primaryMetric: number,
+  primary: FallbackFaceMetrics,
+  fallbackMetric: number,
+  fallback: FallbackFaceMetrics,
+): number {
+  if (
+    primaryMetric <= 0 ||
+    fallbackMetric <= 0 ||
+    primary.unitsPerEm <= 0 ||
+    fallback.unitsPerEm <= 0
+  ) {
+    return 1;
+  }
+  const factor = primaryMetric / primary.unitsPerEm / (fallbackMetric / fallback.unitsPerEm);
+  return Number.isFinite(factor) && factor > 0 ? factor : 1;
+}
+
+/** Match Ghostty's default ic-width fallback size adjustment. */
+export function resolveFallbackScaleAdjustment(
+  primaryFont: Font | null | undefined,
+  fallbackFont: Font | null | undefined,
+): number {
+  if (!primaryFont || !fallbackFont) return 1;
+  const primary = measureFallbackFace(primaryFont);
+  const fallback = measureFallbackFace(fallbackFont);
+
+  // Ghostty only uses ic-width when the fallback has a valid explicit 水
+  // advance. Otherwise it falls through ex-height, cap-height, and
+  // finally line-height while estimating the corresponding primary metric.
+  if (fallback.icWidth > 0) {
+    return normalizedMetricFactor(icWidth(primary), primary, fallback.icWidth, fallback);
+  }
+  if (fallback.exHeight > 0) {
+    return normalizedMetricFactor(exHeight(primary), primary, fallback.exHeight, fallback);
+  }
+  if (fallback.capHeight > 0) {
+    return normalizedMetricFactor(capHeight(primary), primary, fallback.capHeight, fallback);
+  }
+  return normalizedMetricFactor(primary.lineHeight, primary, fallback.lineHeight, fallback);
+}
+
+/** Return a face's valid explicit ideograph advance, if it has one. */
+export function resolveFallbackIcWidth(font: Font | null | undefined): number {
+  return font ? measureFallbackFace(font).icWidth : 0;
+}
+
 export type WideFallbackScaleOptions = {
   scale: number;
   advanceUnits: number;
@@ -38,15 +166,15 @@ export function resolveFallbackTextScale(options: FallbackTextScaleOptions): num
     fontHeightUnits,
     lineHeight,
   } = options;
-  if (maxSpan > 1 && primaryEmScale > 0) {
+  let scale = (primaryEmScale > 0 ? primaryEmScale : baseScale) * metricAdjust;
+  if (maxSpan > 1) {
     return resolveWideFallbackScale({
-      scale: primaryEmScale,
+      scale,
       advanceUnits,
       cellWidth,
       maxSpan,
     });
   }
-  let scale = baseScale * metricAdjust;
   const heightPx = fontHeightUnits * scale;
   if (heightPx > lineHeight && heightPx > 0) scale *= lineHeight / heightPx;
   return scale;

--- a/tests/fallback-font-layout.test.ts
+++ b/tests/fallback-font-layout.test.ts
@@ -2,9 +2,58 @@ import { expect, test } from "bun:test";
 import {
   resolveFallbackBaselineAdjust,
   resolveFallbackGlyphCenterX,
+  resolveFallbackIcWidth,
+  resolveFallbackScaleAdjustment,
   resolveFallbackTextScale,
   resolveWideFallbackScale,
 } from "../src/runtime/fonts/fallback-layout";
+
+function makeMetricFont(options: {
+  unitsPerEm?: number;
+  height: number;
+  ascender: number;
+  asciiAdvance: number;
+  asciiTop: number;
+  asciiBottom: number;
+  waterAdvance?: number;
+  waterWidth?: number;
+  exHeight?: number;
+  capHeight?: number;
+}) {
+  return {
+    unitsPerEm: options.unitsPerEm ?? 1000,
+    height: options.height,
+    ascender: options.ascender,
+    os2: {
+      sxHeight: options.exHeight ?? 0,
+      sCapHeight: options.capHeight ?? 0,
+    },
+    glyphIdForChar(ch: string) {
+      if (ch === "水") return options.waterAdvance ? 0x6c34 : 0;
+      const codepoint = ch.codePointAt(0) ?? 0;
+      return codepoint >= 32 && codepoint < 127 ? codepoint : 0;
+    },
+    advanceWidth(glyphId: number) {
+      return glyphId === 0x6c34 ? (options.waterAdvance ?? 0) : options.asciiAdvance;
+    },
+    getGlyphBounds(glyphId: number) {
+      if (glyphId === 0x6c34) {
+        return {
+          xMin: 0,
+          xMax: options.waterWidth ?? options.waterAdvance ?? 0,
+          yMin: options.asciiBottom,
+          yMax: options.asciiTop,
+        };
+      }
+      return {
+        xMin: 0,
+        xMax: options.asciiAdvance,
+        yMin: options.asciiBottom,
+        yMax: options.asciiTop,
+      };
+    },
+  } as any;
+}
 
 test("wide CJK fallbacks keep their natural em scale", () => {
   const scale = resolveWideFallbackScale({
@@ -17,11 +66,39 @@ test("wide CJK fallbacks keep their natural em scale", () => {
   expect(scale).toBeCloseTo(0.016, 5);
 });
 
-test("wide CJK fallbacks use the primary em instead of their taller line metrics", () => {
+test("wide CJK fallbacks apply Ghostty ic-width normalization at the primary em", () => {
+  // Metrics measured from the bundled JetBrains Mono and Noto Sans CJK SC
+  // faces. JetBrains has no 水, so Ghostty estimates its ideograph width as
+  // min(ASCII height 1050, two 600-unit cells) and compares it with Noto's
+  // explicit 1000-unit 水 advance.
+  const primary = makeMetricFont({
+    height: 1320,
+    ascender: 1020,
+    asciiAdvance: 600,
+    asciiTop: 870,
+    asciiBottom: -180,
+    exHeight: 550,
+    capHeight: 730,
+  });
+  const fallback = makeMetricFont({
+    height: 1448,
+    ascender: 1160,
+    asciiAdvance: 946,
+    asciiTop: 872,
+    asciiBottom: -279,
+    waterAdvance: 1000,
+    waterWidth: 936,
+    exHeight: 543,
+    capHeight: 733,
+  });
+  const metricAdjust = resolveFallbackScaleAdjustment(primary, fallback);
+  expect(metricAdjust).toBeCloseTo(1.05, 6);
+  expect(resolveFallbackIcWidth(fallback)).toBe(1000);
+
   const scale = resolveFallbackTextScale({
     baseScale: 18 / 1448,
     primaryEmScale: 18 / 1320,
-    metricAdjust: 550 / 543,
+    metricAdjust,
     advanceUnits: 1000,
     cellWidth: 8,
     maxSpan: 2,
@@ -29,8 +106,35 @@ test("wide CJK fallbacks use the primary em instead of their taller line metrics
     lineHeight: 18,
   });
 
-  expect(scale).toBeCloseTo(18 / 1320, 6);
-  expect(1000 * scale).toBeCloseTo(13.63636);
+  expect(scale).toBeCloseTo((18 / 1320) * 1.05, 6);
+  expect(1000 * scale).toBeCloseTo(14.31818);
+});
+
+test("invalid fallback ic-width falls through to normalized ex-height", () => {
+  const primary = makeMetricFont({
+    unitsPerEm: 2000,
+    height: 2400,
+    ascender: 1900,
+    asciiAdvance: 1200,
+    asciiTop: 1700,
+    asciiBottom: -300,
+    exHeight: 1100,
+    capHeight: 1460,
+  });
+  const fallback = makeMetricFont({
+    height: 1448,
+    ascender: 1160,
+    asciiAdvance: 946,
+    asciiTop: 872,
+    asciiBottom: -279,
+    waterAdvance: 500,
+    waterWidth: 936,
+    exHeight: 543,
+    capHeight: 733,
+  });
+
+  expect(resolveFallbackIcWidth(fallback)).toBe(0);
+  expect(resolveFallbackScaleAdjustment(primary, fallback)).toBeCloseTo(550 / 543, 6);
 });
 
 test("wide fallback glyphs are centered across their occupied cells", () => {

--- a/tests/symbol-rendering.test.ts
+++ b/tests/symbol-rendering.test.ts
@@ -136,7 +136,7 @@ test("symbol constraints remain table-driven without per-codepoint overrides", (
   expect(resolveSymbolConstraint(0x15e3)).toBeNull();
 });
 
-test("fallback font scaling routes primary-em wide faces through the shared resolver", () => {
+test("fallback font scaling routes Ghostty metric adjustment through the shared resolver", () => {
   const webgpuSource = readFileSync(
     join(process.cwd(), "src/runtime/create-runtime/render-tick-webgpu-cell-pass.ts"),
     "utf8",
@@ -145,12 +145,10 @@ test("fallback font scaling routes primary-em wide faces through the shared reso
     join(process.cwd(), "src/runtime/create-runtime/render-tick-webgl-context.ts"),
     "utf8",
   );
-  const metricOrderPattern = /"ic_width",\s+"ex_height",\s+"cap_height",\s+"line_height"/g;
-  expect((webgpuSource.match(metricOrderPattern) ?? []).length).toBeGreaterThanOrEqual(1);
-  expect((webglSource.match(metricOrderPattern) ?? []).length).toBeGreaterThanOrEqual(1);
-  const upscaleOnlyPattern = /clamp\(fallbackScaleAdjustment\(primaryEntry, entry\), 1, 2\)/g;
-  expect((webgpuSource.match(upscaleOnlyPattern) ?? []).length).toBe(1);
-  expect((webglSource.match(upscaleOnlyPattern) ?? []).length).toBe(1);
+  const metricAdjustmentPattern =
+    /const metricAdjust = resolveFallbackScaleAdjustment\(primaryEntry\?\.font, entry\.font\);/g;
+  expect((webgpuSource.match(metricAdjustmentPattern) ?? []).length).toBe(1);
+  expect((webglSource.match(metricAdjustmentPattern) ?? []).length).toBe(1);
   const sharedScalePattern = /resolveFallbackTextScale\(\{/g;
   expect((webgpuSource.match(sharedScalePattern) ?? []).length).toBe(1);
   expect((webglSource.match(sharedScalePattern) ?? []).length).toBe(1);


### PR DESCRIPTION
## Summary

- replace the wide-fallback primary-em shortcut with Ghostty's default em-normalized `ic_width` adjustment
- measure the primary printable-ASCII box and the fallback `水` advance, with Ghostty-compatible ex-height, cap-height, and line-height fallbacks
- share the metric implementation between WebGPU and WebGL2 while preserving the common baseline and two-cell safety cap
- add regression coverage using the bundled JetBrains Mono and Noto Sans CJK metrics
- prepare restty 0.2.4

## Root cause

Version 0.2.3 forced wide fallback faces to the primary em scale but bypassed the existing metric adjustment. Ghostty instead scales ordinary fallback faces by an em-normalized `ic_width` ratio. For the bundled fonts, this ratio is `1050 / 1000 = 1.05`; retaining it increases the CJK advance from 13.64 px to 14.32 px in a 16 px two-cell span and removes the excess whitespace.

## Validation

- `bun test tests/fallback-font-layout.test.ts tests/symbol-rendering.test.ts`
- PowerShell equivalent of `bun run test:ci`: 316 tests passed
- live bundled-font metric probe: `metricAdjust=1.05`, `advancePx=14.3181818`
- `bun run build:types`
- `bun run check:themes`
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `bun run playground:build`
- release-note extraction for 0.2.4

Fixes #24
