### PR TITLE
fix(fonts): update text-shaper to 0.1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This project follows SemVer. While restty is pre-1.0, breaking public API change
 
 ### Docs
 
+## [0.2.5] - 2026-07-16
+
+### Fixes
+
+- Updated text-shaper to 0.1.27 so Unicode variation sequences use cmap format 14 mappings and surviving selectors are removed before positioning, restoring VS16 color emoji rendering and preserving adjacent kerning.
+
 ## [0.2.4] - 2026-07-16
 
 ### Fixes

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "restty",
       "dependencies": {
-        "text-shaper": "0.1.26",
+        "text-shaper": "0.1.27",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
@@ -872,7 +872,7 @@
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
-    "text-shaper": ["text-shaper@0.1.26", "", {}, "sha512-tTLEZskIQYadTw7pNQpGstZGLZX/TPbMreexrxtJzTQCQe9upWYfEcJxDW3yN+m3NhO1kI2v/BUor+qyCpOm+Q=="],
+    "text-shaper": ["text-shaper@0.1.27", "", {}, "sha512-kfuOgxNHEHGfYaMJ5uaMbNfnmS5adMG3qPjLAgwwEy9pBsqAj4F0oSkOl8QoOdnQ8+wyIkX7M+hBYA4btWB4sw=="],
 
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restty",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Browser terminal rendering library powered by WASM, WebGPU/WebGL2, and TypeScript text shaping.",
   "keywords": [
     "ansi",
@@ -97,7 +97,7 @@
     "playground:preview": "bun run playground/server.ts"
   },
   "dependencies": {
-    "text-shaper": "0.1.26"
+    "text-shaper": "0.1.27"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",


### PR DESCRIPTION
## Summary

- update the runtime dependency from text-shaper 0.1.26 to 0.1.27
- lock the published package and prepare restty 0.2.5
- restore VS16 color emoji rendering through single-glyph variation-sequence shaping
- preserve pair positioning when selectors occur between adjacent glyphs

## Root cause

Text-shaper parsed cmap format 14 but did not consult it during shaping, so variation selectors survived as extra glyphs. Restty's color glyph recording requires single-glyph clusters, causing Apple Color Emoji VS16 sequences to be omitted from the canvas atlas. Text-shaper 0.1.27 maps format-14 variation sequences and removes surviving selectors after substitution but before positioning.

## Validation

- installed-package probe confirms text-shaper 0.1.27
- `A + VS16 + V` has the same glyph IDs and `[1273, 1413]` advances as `AV`
- live Noto CJK format-14 IVS maps to the expected non-default glyph
- 316 CI-safe tests passed
- `bun run check:themes`
- `bun run format:check`
- `bun run lint`
- `bun run build:types`
- `bun run build`
- `bun run playground:build`
- release-note extraction for 0.2.5

Addresses #30

Upstream: wiedymi/text-shaper#5
