### PR TITLE
fix(fonts): update text-shaper to 0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This project follows SemVer. While restty is pre-1.0, breaking public API change
 
 ### Docs
 
+## [0.2.6] - 2026-07-17
+
+### Fixes
+
+- Updated text-shaper to 0.1.28 so Apple Color Emoji's AAT `morx` ligatures compose regional-indicator flags, keycaps, ZWJ families, rainbow flags, and skin-tone sequences into single color glyphs, with spec-correct no-op substitutions and hardened action-stack and parser-boundary handling.
+
 ## [0.2.5] - 2026-07-16
 
 ### Fixes

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "restty",
       "dependencies": {
-        "text-shaper": "0.1.27",
+        "text-shaper": "0.1.28",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
@@ -872,7 +872,7 @@
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
-    "text-shaper": ["text-shaper@0.1.27", "", {}, "sha512-kfuOgxNHEHGfYaMJ5uaMbNfnmS5adMG3qPjLAgwwEy9pBsqAj4F0oSkOl8QoOdnQ8+wyIkX7M+hBYA4btWB4sw=="],
+    "text-shaper": ["text-shaper@0.1.28", "", {}, "sha512-uwm6+tkgYJ4hsTV0wZVHkZeoXR1/mthLxDiJvfU9o/FiibNinpFRC8PAMTNx8SaOjaK/5ZjDG1XAkPbKlIe2Jg=="],
 
     "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restty",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Browser terminal rendering library powered by WASM, WebGPU/WebGL2, and TypeScript text shaping.",
   "keywords": [
     "ansi",
@@ -97,7 +97,7 @@
     "playground:preview": "bun run playground/server.ts"
   },
   "dependencies": {
-    "text-shaper": "0.1.27"
+    "text-shaper": "0.1.28"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",


### PR DESCRIPTION
## Summary

- update the runtime dependency from text-shaper 0.1.27 to 0.1.28
- prepare and lock restty 0.2.6
- compose Apple Color Emoji flags, keycaps, ZWJ families, rainbow flags, and skin-tone sequences as single glyphs
- preserve VS16 behavior from text-shaper 0.1.27

## Root cause

Apple Color Emoji implements complex emoji sequences as AAT `morx` ligatures. Text-shaper's class lookup, ligature-table parsing, and state-machine action processing were incomplete, so the sequences remained separate component glyphs and could not enter restty's single-glyph color atlas path.

Text-shaper 0.1.28 implements the missing lookup and ligature data, follows Apple/HarfBuzz action semantics, treats zero substitutions as no-ops, bounds binary-table regions, rejects invalid component indices, and avoids duplicate component pushes across `DontAdvance` transitions.

## Validation

- exact installed dependency: `text-shaper@0.1.28`
- 6 cross-platform upstream morx regressions passed
- 316 restty CI-safe tests passed
- `bun install --frozen-lockfile`
- `bun run check:themes`
- `bun run format:check`
- `bun run lint`
- `bun run build:types`
- `bun run build`
- `bun run playground:build`
- release-note extraction for 0.2.6

Upstream: wiedymi/text-shaper#6
Follow-up to #30
